### PR TITLE
Added gazebo plugins as a dependecy so the scan topic will be published.

### DIFF
--- a/beginner/package.xml
+++ b/beginner/package.xml
@@ -9,6 +9,7 @@
   <license>TODO</license>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <exec_depend>gazebo_plugins</exec_depend>
   <exec_depend>turtlebot3_navigation</exec_depend>
   <exec_depend>turtlebot3_gazebo</exec_depend>
   <exec_depend>dwa_local_planner</exec_depend>


### PR DESCRIPTION
I tested this in a docker container and the rosdep install grabs all of the required packages now. 